### PR TITLE
Update job.go

### DIFF
--- a/cmd/job.go
+++ b/cmd/job.go
@@ -184,7 +184,7 @@ func jobRun(cmd *cobra.Command, args []string) {
 		case event := <-eventchannel:
 			pj, ok = event.Object.(*pjapi.ProwJob)
 			if !ok {
-				log.Fatalf("Received unexpected object type from watch: object-type %T", event.Object)
+				log.Fatalf("Received unexpected object type from watch: object-type %v", event)
 			}
 
 			if pj.Status.State == pjapi.FailureState || pj.Status.State == pjapi.ErrorState || pj.Status.State == pjapi.AbortedState {


### PR DESCRIPTION
Changing event.Object to event and the format string to %v from %T to see if any useful troubleshooting data is returned. Currently when this error is triggered nothing is printed.