### PR TITLE
refactoring to allow for building and releasing of images

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,0 +1,89 @@
+name: Build Main
+
+on:
+  push:
+    branches: [ main, ghactions ]
+
+env:
+  IMAGE_NAME: preflight-trigger
+  
+jobs:
+  build-main:
+    name: Build and push main snapshot images
+    strategy: 
+      matrix:
+        architecture: [amd64]
+        platform: [linux]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Fetch latest release version
+      uses: reloc8/action-latest-release-version@1.0.0
+      id: fetch-latest-release
+    - name: Set Env Tags
+      run: echo RELEASE_TAG=${{ steps.fetch-latest-release.outputs.latest-release }} >> $GITHUB_ENV
+    - name: set short sha
+      run: echo SHA_SHORT=$(git rev-parse --short HEAD) >> $GITHUB_ENV
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+        
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ secrets.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+        # TODO: If we end up releasing for other architectures we'll need the below
+        # tags: ${{ env.SHA_SHORT }}-${{ matrix.platform }}-${{ matrix.architecture }}
+        tags: ${{ env.SHA_SHORT }}
+        archs: ${{ matrix.architecture }}
+        build-args: |
+          quay_expiration=1w
+          release_tag=${{ env.RELEASE_TAG }}+${{ github.sha }}
+          ARCH=${{ matrix.architecture }}
+        dockerfiles: |
+          ./Dockerfile
+
+    - name: Push Image
+      id: push-image
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        # TODO: If we end up releasing for other architectures we'll need the below
+        # tags: ${{ env.SHA_SHORT }}-${{ matrix.platform }}-${{ matrix.architecture }}
+        tags: ${{ env.SHA_SHORT }}
+        registry: ${{ secrets.IMAGE_REGISTRY }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-image.outputs.registry-paths }}"
+    
+    outputs:
+      imageName: ${{ env.IMAGE_NAME }}
+      imageVersion: ${{ env.SHA_SHORT }}
+
+  build-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install system deps
+      run: 'sudo apt update && sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev'
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
+    - name: Tidy
+      run: make tidy
+
+    - name: Vet
+      run: make vet
+
+    - name: Format
+      run: make fmt
+
+    - name: Test
+      run: make cover

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,61 @@
+name: Build Release
+
+on:
+  release:
+    types:
+      - published
+  push:
+    branches: [ ghactions ]
+
+env:
+  IMAGE_NAME: preflight-trigger
+
+jobs:
+  build-release:
+    name: Build and push tag images
+    strategy: 
+      matrix:
+        architecture: [amd64]
+        platform: [linux]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set Env Tags
+      run: echo RELEASE_TAG=$(echo $GITHUB_REF | cut -d '/' -f 3) >> $GITHUB_ENV
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ secrets.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+        # TODO: If we end up releasing for other architectures we'll need the below
+        # tags: ${{ env.RELEASE_TAG }}-${{ matrix.platform }}-${{ matrix.architecture }}
+        tags: ${{ env.RELEASE_TAG }}
+        archs: ${{ matrix.architecture }}
+        build-args: |
+          release_tag=${{env.RELEASE_TAG }}
+          ARCH=${{ matrix.architecture }}
+        dockerfiles: |
+          ./Dockerfile
+
+    - name: Push Image
+      id: push-image
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        # TODO: If we end up releasing for other architectures we'll need the below
+        # tags: ${{ env.RELEASE_TAG }}-${{ matrix.platform }}-${{ matrix.architecture }}
+        tags: ${{ env.RELEASE_TAG }}
+        registry: ${{ secrets.IMAGE_REGISTRY }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-image.outputs.registry-paths }}"
+
+    outputs:
+      imageName: ${{ env.IMAGE_NAME }}
+      imageVersion: ${{ env.RELEASE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+ARG quay_expiration=never
+ARG release_tag=0.0.0
+ARG ARCH=amd64
+ARG OS=linux
+
+FROM docker.io/golang:1.21 AS builder
+ARG quay_expiration
+ARG release_tag
+ARG ARCH
+ARG OS
+
+# Build the preflight binary
+COPY . /go/src/preflight-trigger
+WORKDIR /go/src/preflight-trigger
+RUN make build
+
+
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+ARG quay_expiration
+ARG release_tag
+ARG ARCH
+ARG OS
+
+# Metadata
+LABEL name="Preflight Trigger" \
+      vendor="Red Hat, Inc." \
+      maintainer="Red Hat OpenShift Ecosystem" \
+      version="1" \
+      summary="Provides the OpenShift Preflight Trigger tool." \
+      description="Preflight Trigger calls prow jobs to provision OpenShift clusters." \
+      url="https://github.com/redhat-openshift-ecosystem/preflight-trigger" \
+      release=${release_tag}
+
+
+# Define that tags should expire after 1 week. This should not apply to versioned releases.
+LABEL quay.expires-after=${quay_expiration}
+
+# Fetch the build image Architecture
+LABEL ARCH=${ARCH}
+LABEL OS=${OS}
+
+# Add preflight-trigger binary
+COPY --from=builder /go/src/preflight-trigger/preflight-trigger /usr/local/bin/preflight-trigger
+
+#copy license
+COPY LICENSE /licenses/LICENSE
+
+CMD ["preflight-trigger"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,22 @@ export CONTAINER_ENGINE ?= podman
 export BIN_NAME
 export REGISTRY ?= quay.io
 export REGISTRY_NAMESPACE ?= opdev
-export IMAGE_TAG ?= latest
+export RELEASE_TAG ?= "0.0.0"
 
+
+.PHONY: binary-build
 binary-build:
-	$(CONTAINER_ENGINE) run --rm -v $(PWD):/usr/src/$(BIN_NAME) -w /usr/src/$(BIN_NAME) -e GOOS=linux -e GOARCH=amd64 docker.io/library/golang:alpine go build -o build/$(BIN_NAME)
+	$(CONTAINER_ENGINE) run --rm -v $(PWD):/usr/src/$(BIN_NAME) -w /usr/src/$(BIN_NAME) -e GOOS=linux -e GOARCH=amd64 docker.io/library/golang:alpine go build -o $(BIN_NAME)
 
+.PHONY: image-build
 image-build:
-	cd build && $(CONTAINER_ENGINE) build -t $(REGISTRY)/$(REGISTRY_NAMESPACE)/$(BIN_NAME):$(IMAGE_TAG) .
+	$(CONTAINER_ENGINE) build --build-arg release_tag=$(RELEASE_TAG) -t $(REGISTRY)/$(REGISTRY_NAMESPACE)/$(BIN_NAME):$(RELEASE_TAG) .
+
+.PHONY: image-push
 image-push:
-	$(CONTAINER_ENGINE) push $(REGISTRY)/$(REGISTRY_NAMESPACE)/$(BIN_NAME):$(IMAGE_TAG)
+	$(CONTAINER_ENGINE) push $(REGISTRY)/$(REGISTRY_NAMESPACE)/$(BIN_NAME):$(RELEASE_TAG)
+
+.PHONY: build
+build:
+	CGO_ENABLED=0 go build -o $(BIN_NAME) main.go
+	@ls build | grep -e '^preflight-trigger$$' &> /dev/null

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,0 @@
-FROM registry.redhat.io/ubi9/ubi-micro
-
-COPY preflight-trigger /usr/local/bin
-
-CMD ["preflight-trigger"]


### PR DESCRIPTION
### Changes
- Updating the project structure so Dockerfile can be used by build/release process
- Adding Build and Release jobs to push images to a container registry

### Validation
- Release from my fork: https://github.com/acornett21/preflight-trigger/releases/tag/0.0.2
- Images pushed from main/release job: https://quay.io/repository/acornett/preflight-trigger?tab=tags

**Note: This PR is dependent on other PR's with updated make file changes for `build`, `vet`, `fmt`, etc.**