### PR TITLE
updating go version to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG release_tag=0.0.0
 ARG ARCH=amd64
 ARG OS=linux
 
-FROM docker.io/golang:1.22 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG quay_expiration
 ARG release_tag
 ARG ARCH

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 endef
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.58.0
+GOLANGCI_LINT_VERSION ?= v1.62.2
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/redhat-openshift-ecosystem/preflight-trigger
 
-go 1.22.0
-
-toolchain go1.22.1
+go 1.23.2
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.8.1

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -8,5 +8,5 @@ type PreflightTriggerCustomError struct {
 }
 
 func (e *PreflightTriggerCustomError) Error() string {
-	return fmt.Sprintf(e.Message + ": " + e.Err.Error())
+	return fmt.Sprintf(e.Message+": %s", e.Err.Error())
 }


### PR DESCRIPTION
## Changes
- Updated `go` to latest 1.23 version
- Updated `golangci-lint` to build/run properly with go 1.23
- Fixing linting issue from new version of linter