### PR TITLE
Update lint to use golangci-lint v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,55 +1,75 @@
+version: "2"
 run:
-  # Default timeout is 1m, up to give more room
+  # Default timeout is 0 (no limit), have an upper limit
   timeout: 4m
-
-linters:
-  enable:
-  - asciicheck
-  - unused
-  - depguard
-  - gofumpt
-  - goimports
-  - importas
-  - revive
-  - misspell
-  - stylecheck
-  - tparallel
-  - unconvert
-  - unparam
-  - whitespace
-
-linters-settings:
-  importas:
-    alias:
-    - pkg: k8s.io/api/core/v1
-      alias: corev1
-    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-      alias: metav1
-    - pkg: k8s.io/apimachinery/pkg/api/errors
-      alias: apierrors
-    - pkg: github.com/openshift/api/config/v1
-      alias: osconfigv1
-  revive:
-    rules:
-    - name: dot-imports
-      severity: warning
-      disabled: true
-  stylecheck:
-    dot-import-whitelist:
-      - github.com/onsi/gomega
-      - github.com/onsi/ginkgo
-      - github.com/onsi/ginkgo/v2
-  goimports:
-    local-prefixes: github.com/redhat-openshift-ecosystem/preflight-trigger
-  depguard:
-    rules:
-      main:
-        list-mode: lax
-        files:
-          - !$test
-        allow:
-          - $gostd
-
 output:
   formats:
-    - format: tab
+    tab:
+      path: stdout
+      colors: false
+linters:
+  enable:
+    - asciicheck
+    - depguard
+    - importas
+    - misspell
+    - revive
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          files:
+            - ""
+          allow:
+            - $gostd
+    importas:
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: github.com/openshift/api/config/v1
+          alias: osconfigv1
+    revive:
+      rules:
+        - name: dot-imports
+          severity: warning
+          disabled: true
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/gomega
+        - github.com/onsi/ginkgo
+        - github.com/onsi/ginkgo/v2
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/redhat-openshift-ecosystem/preflight-trigger
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 endef
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.62.2
+GOLANGCI_LINT_VERSION ?= v2.1.6
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -113,7 +113,7 @@ func jobPreRun(cmd *cobra.Command, args []string) {
 }
 
 func jobRun(cmd *cobra.Command, args []string) {
-	configagent, err := CommandFlags.ConfigOptions.ConfigAgent()
+	configagent, err := CommandFlags.ConfigAgent()
 	if err != nil {
 		log.Fatalf("%v", err)
 	}


### PR DESCRIPTION
- Update Makefile to get and use golangci-lint v2
- Update .golangci-lint.yaml file to match v2 config file format
- Address/ignore findings raised by staticcheck