### PR TITLE
switching to hardened images to reduce image size and CVE footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG release_tag=0.0.0
 ARG ARCH=amd64
 ARG OS=linux
 
-FROM docker.io/golang:1.26 AS builder
+FROM registry.access.redhat.com/hi/go:1.26-builder AS builder
 ARG quay_expiration
 ARG release_tag
 ARG ARCH
@@ -15,7 +15,7 @@ WORKDIR /go/src/preflight-trigger
 RUN make build RELEASE_TAG=${release_tag}
 
 
-FROM registry.access.redhat.com/ubi10/ubi-micro:latest
+FROM registry.access.redhat.com/hi/core-runtime:latest
 ARG quay_expiration
 ARG release_tag
 ARG ARCH
@@ -44,5 +44,8 @@ COPY --from=builder /go/src/preflight-trigger/preflight-trigger /usr/local/bin/p
 
 #copy license
 COPY LICENSE /licenses/LICENSE
+
+# Switching to root user, for backwards compatability
+USER 0
 
 CMD ["preflight-trigger"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container build and runtime base images to newer Red Hat UBI-based equivalents for improved compatibility and maintenance.
  * Adjusted the final image execution context to run as the root user before applying the existing startup command, while preserving current build steps, labels, and binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->