### PR TITLE
ci: separate test deps from prod in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,14 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dev-dependencies:
-        dependency-type: "development"
+      test-dependencies:
+        patterns:
+          - "github.com/onsi/ginkgo*"
+          - "github.com/onsi/gomega*"
       prod-dependencies:
-        dependency-type: "production"
+        exclude-patterns:
+          - "github.com/onsi/ginkgo*"
+          - "github.com/onsi/gomega*"
     cooldown:
       default-days: 7
   - package-ecosystem: github-actions


### PR DESCRIPTION
Similar to https://github.com/redhat-openshift-ecosystem/openshift-preflight/commit/61a14e8ccae8f29c2eba65f17bbf5bf0a584367f.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update rules for Go modules to better separate test-related packages from production dependencies.
  * Adjusted package grouping so Ginkgo/Gomega updates are handled as test dependencies and excluded from production dependency grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->