### PR TITLE
Revert "switching to hardened images to reduce image size and CVE footprint"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG release_tag=0.0.0
 ARG ARCH=amd64
 ARG OS=linux
 
-FROM registry.access.redhat.com/hi/go:1.26-builder AS builder
+FROM docker.io/golang:1.26 AS builder
 ARG quay_expiration
 ARG release_tag
 ARG ARCH
@@ -15,7 +15,7 @@ WORKDIR /go/src/preflight-trigger
 RUN make build RELEASE_TAG=${release_tag}
 
 
-FROM registry.access.redhat.com/hi/core-runtime:latest
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 ARG quay_expiration
 ARG release_tag
 ARG ARCH
@@ -44,8 +44,5 @@ COPY --from=builder /go/src/preflight-trigger/preflight-trigger /usr/local/bin/p
 
 #copy license
 COPY LICENSE /licenses/LICENSE
-
-# Switching to root user, for backwards compatability
-USER 0
 
 CMD ["preflight-trigger"]


### PR DESCRIPTION
Reverts redhat-openshift-ecosystem/preflight-trigger#133

Need to revert this change, since it seems not all arches are supported, even though documentation says otherwise.

```
❯ crane manifest registry.access.redhat.com/hi/core-runtime:latest | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:a793ae2e6969409a2dab5bfdf9823cb77bc3cb2a43ba6dcd1c9b17d8b063bdca",
      "size": 4272,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:ec589a753ffc6589bdc540330b8271eab82281a12eb6559b5d4d23c194c4a267",
      "size": 4272,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    }
  ]
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build and runtime base images.
  * Removed the explicit root-user configuration from the runtime image.
  * Preserved the existing container startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->